### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/exotic_ld/ld_grids.py
+++ b/exotic_ld/ld_grids.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 from scipy.spatial import KDTree
 
 from exotic_ld.ld_requests import download
@@ -41,9 +41,8 @@ class StellarGrids(object):
                            self.logg_input / self._r_logg])
 
     def _get_stellar_model_kd_tree(self):
-        tree_path = pkg_resources.resource_filename(
-            "grid_build.kd_trees", "{}_tree{}.pickle".format(
-                self.ld_model, self._ld_data_version))
+        filename = "{}_tree{}.pickle".format(self.ld_model, self._ld_data_version)
+        tree_path = str(resources.files("grid_build.kd_trees").joinpath(filename))
         try:
             with open(tree_path, "rb") as f:
                 self._stellar_kd_tree = pickle.load(f)

--- a/exotic_ld/ld_grids.py
+++ b/exotic_ld/ld_grids.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import numpy as np
-from importlib.resources import files
+from importlib import resources
 from scipy.spatial import KDTree
 
 from exotic_ld.ld_requests import download


### PR DESCRIPTION
This resolves a deprecation warning related to pkg_resources.resource_filename, which was slated for removal in late 2025. All uses were replaced with the modern importlib.resources.files() API. This change requires Python 3.9+.

In particular, the previous warning message was:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```